### PR TITLE
iOS Mobile Nav Fix

### DIFF
--- a/src/components/MainNav.astro
+++ b/src/components/MainNav.astro
@@ -134,6 +134,7 @@
       navToggle?.blur();
       state = false;
     } else {
+      navToggle?.focus();
       state = true;
     }
   });


### PR DESCRIPTION
On iOs devices, the button focus state is immediately blurred, so this PR manually applies is via JS. 

This will be re-evaluated in a future PR focusing on accessibility  